### PR TITLE
Fix: Ensure correct display of sensor title in LineGraph component

### DIFF
--- a/biologging-sensor-data/src/app/visualisation/[id]/SensorsList.tsx
+++ b/biologging-sensor-data/src/app/visualisation/[id]/SensorsList.tsx
@@ -1,50 +1,49 @@
-import { useEffect } from "react";
+import { Event } from "@/api/event/event.typscript";
+import { useEffect, useState } from "react";
 import { SensorList } from "./interface";
 import { handleSensorSelection } from "@/hooks/sensorSelectContext/sensorSelectContext";
-import { Dataset } from "@/api/dataset/dataset.interface";
 
-interface Props {
-    selectedDataset: Dataset | null;
+interface Args {
+    events: Event[];
 }
 
-export default function SensorsList({ selectedDataset }: Props) {
+
+export default function SensorsList({ events }: Args) {
     const { sensors, updateSensors } = handleSensorSelection();
 
     useEffect(() => {
-        if (selectedDataset) {
-            const values: SensorList[] = selectedDataset.sensorTypes.map(item => ({
-                sensor: item,
-                selected: false,
-            }));
-            updateSensors(values);
+        // identify sensors
+        const sensorSet = new Set<string>();
+
+        for (const e of events) {
+            e.valuesMeasured.map((itm) => {
+                sensorSet.add(itm);
+            })
         }
-    }, [selectedDataset])
+
+        const sorted = Array.from(sensorSet).sort();
+
+        const values: SensorList[] = sorted.map(item => ({
+            sensor: item,
+            selected: false,
+        }));
+
+        updateSensors(values);
+    }, [events])
 
     function _selectSensor(i: number) {
-        const updatedSensors = sensors.map((sensor, index) => {
-            if (index === i) {
-                return {
-                    ...sensor,
-                    selected: !sensor.selected
-                };
-            }
-            return sensor;
-        });
-        updateSensors(updatedSensors);
+        const s = [...sensors];
+        s[i].selected = !s[i].selected;
+        updateSensors(s);
     }
 
     return (
         <div>
             <h5>Select sensor</h5>
-            {sensors.map((item, index) => (
-                <div
-                    style={item.selected ? { backgroundColor: "lightblue" } : undefined}
-                    key={index}
-                    onClick={() => _selectSensor(index)}
-                >
-                    {item.sensor}
-                </div>
-            ))}
+            {sensors.map((item, index) => {
+                return <div style={item.selected ? { backgroundColor: "lightblue" } : undefined} key={index} onClick={() => _selectSensor(index)}>{item.sensor}</div>
+            })}
         </div>
-    );
+    )
+
 }

--- a/biologging-sensor-data/src/components/graphs/line/LineGraph.tsx
+++ b/biologging-sensor-data/src/components/graphs/line/LineGraph.tsx
@@ -105,16 +105,7 @@ export default function LineGraph({ events, sensor }: { events: Event[], sensor:
     fetchData();
   }, [sensor, events]);
   
-  
-  // useEffect(() => {
-  //   setOptions(prevOptions => ({
-  //     ...prevOptions,
-  //     title: {
-  //       ...prevOptions.title,
-  //       text: sensor.toUpperCase(),
-  //     },
-  //   }));
-  // }, [sensor]);
+
 
   useEffect(() => {
     setOptions(prevOptions => ({

--- a/biologging-sensor-data/src/components/graphs/line/LineGraph.tsx
+++ b/biologging-sensor-data/src/components/graphs/line/LineGraph.tsx
@@ -106,16 +106,30 @@ export default function LineGraph({ events, sensor }: { events: Event[], sensor:
   }, [sensor, events]);
   
   
+  // useEffect(() => {
+  //   setOptions(prevOptions => ({
+  //     ...prevOptions,
+  //     title: {
+  //       ...prevOptions.title,
+  //       text: sensor.toUpperCase(),
+  //     },
+  //   }));
+  // }, [sensor]);
+
   useEffect(() => {
     setOptions(prevOptions => ({
       ...prevOptions,
-      title: {
-        ...prevOptions.title,
-        text: sensor.toUpperCase(),
+      plugins: {
+        ...prevOptions.plugins,
+        title: {
+          ...prevOptions.plugins.title,
+          text: sensor.toUpperCase(),
+        },
       },
     }));
   }, [sensor]);
 
+  
   useEffect(() => {
     setOptions(prevOptions => ({
       ...prevOptions,


### PR DESCRIPTION
## Changes Made

- Corrected the code in the LineGraph component to ensure the correct display of the sensor title: [JIRA Task 107](https://biologging-data-lu.atlassian.net/browse/BIOSENSOR-107?atlOrigin=eyJpIjoiM2EwM2MyNmQ4M2MzNDJmN2I1NzgzZTg1ODc0ZTg5YzAiLCJwIjoiaiJ9)
- Reverted changes made in SensorsList.tsx manually due to unsuccessful implementation of passing `selectedDataset` as a prop. (Please Note: The[ status of the JIRA Task 103 ](https://biologging-data-lu.atlassian.net/browse/BIOSENSOR-103?atlOrigin=eyJpIjoiNjJlNTk3NDM2OTVjNDFlMGE0ZWY3MzFkZDA4NzAwYTIiLCJwIjoiaiJ9)will be changed to TO DO since the new approach did not work out for now)

## Additional Context 

 [ JIRA Task 103 ](https://biologging-data-lu.atlassian.net/browse/BIOSENSOR-103?atlOrigin=eyJpIjoiNjJlNTk3NDM2OTVjNDFlMGE0ZWY3MzFkZDA4NzAwYTIiLCJwIjoiaiJ9): The initial attempt to pass `selectedDataset` as a prop to `SensorsList.tsx` and fetch sensor data using the useEffect hook did not achieve the desired outcome. As a result, the code changes were reverted manually to maintain functionality.

[JIRA Task 107](https://biologging-data-lu.atlassian.net/browse/BIOSENSOR-107?atlOrigin=eyJpIjoiM2EwM2MyNmQ4M2MzNDJmN2I1NzgzZTg1ODc0ZTg5YzAiLCJwIjoiaiJ9): The corrected code in `LineGraph` component now accurately displays the sensor title, resolving the issue identified.

